### PR TITLE
Fix for #44 by updating parsing logic of interface config when more than 1 NAT Pool is defined

### DIFF
--- a/cloudgenix_config/do.py
+++ b/cloudgenix_config/do.py
@@ -2976,7 +2976,8 @@ def create_interface(config_interface, interfaces_n2id, waninterfaces_n2id, lann
                 n2id_np_template = copy.deepcopy(config_nat_pools)
 
                 # replace flat names in dict
-                name_lookup_in_template(n2id_np_template, 'nat_pool_id', natpolicypools_n2id)
+                for template in n2id_np_template:
+                    name_lookup_in_template(template, 'nat_pool_id', natpolicypools_n2id)
 
                 # update template
                 interface_template["nat_pools"] = n2id_np_template


### PR DESCRIPTION
This pull request handles the case when multiple NAT pools are defined within an interface. The individual nat_pool definitions will be mutated using `name_lookup_in_template`. This has been created to solve for #44.